### PR TITLE
Update cluster-gateway and cluster-proxy charts to v2026.6.26

### DIFF
--- a/charts/cluster-gateway-manager/Chart.yaml
+++ b/charts/cluster-gateway-manager/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cluster-gateway-manager
 description: A Helm chart for Cluster-Gateway Addon-Manager
 type: application
-version: v2026.2.16
-appVersion: v1.12.0
+version: v2026.6.26
+appVersion: v1.12.1

--- a/charts/cluster-gateway-manager/README.md
+++ b/charts/cluster-gateway-manager/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable
 $ helm repo update
-$ helm search repo appscode/cluster-gateway-manager --version=v2026.2.16
-$ helm upgrade -i cluster-gateway-manager appscode/cluster-gateway-manager -n open-cluster-management-addon --create-namespace --version=v2026.2.16
+$ helm search repo appscode/cluster-gateway-manager --version=v2026.6.26
+$ helm upgrade -i cluster-gateway-manager appscode/cluster-gateway-manager -n open-cluster-management-addon --create-namespace --version=v2026.6.26
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a cluster-gateway-manager on a [Kubernetes](http://kubernetes
 To install/upgrade the chart with the release name `cluster-gateway-manager`:
 
 ```bash
-$ helm upgrade -i cluster-gateway-manager appscode/cluster-gateway-manager -n open-cluster-management-addon --create-namespace --version=v2026.2.16
+$ helm upgrade -i cluster-gateway-manager appscode/cluster-gateway-manager -n open-cluster-management-addon --create-namespace --version=v2026.6.26
 ```
 
 The command deploys a cluster-gateway-manager on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -69,12 +69,12 @@ The following table lists the configurable parameters of the `cluster-gateway-ma
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i cluster-gateway-manager appscode/cluster-gateway-manager -n open-cluster-management-addon --create-namespace --version=v2026.2.16 --set image=ghcr.io/kluster-manager/cluster-gateway-manager
+$ helm upgrade -i cluster-gateway-manager appscode/cluster-gateway-manager -n open-cluster-management-addon --create-namespace --version=v2026.6.26 --set image=ghcr.io/kluster-manager/cluster-gateway-manager
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i cluster-gateway-manager appscode/cluster-gateway-manager -n open-cluster-management-addon --create-namespace --version=v2026.2.16 --values values.yaml
+$ helm upgrade -i cluster-gateway-manager appscode/cluster-gateway-manager -n open-cluster-management-addon --create-namespace --version=v2026.6.26 --values values.yaml
 ```

--- a/charts/cluster-gateway/Chart.yaml
+++ b/charts/cluster-gateway/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cluster-gateway
 description: A Helm chart for Cluster-Gateway
 type: application
-version: v2026.2.16
-appVersion: v1.12.0
+version: v2026.6.26
+appVersion: v1.12.1

--- a/charts/cluster-gateway/README.md
+++ b/charts/cluster-gateway/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable
 $ helm repo update
-$ helm search repo appscode/cluster-gateway --version=v2026.2.16
-$ helm upgrade -i cluster-gateway appscode/cluster-gateway -n open-cluster-management --create-namespace --version=v2026.2.16
+$ helm search repo appscode/cluster-gateway --version=v2026.6.26
+$ helm upgrade -i cluster-gateway appscode/cluster-gateway -n open-cluster-management --create-namespace --version=v2026.6.26
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a cluster-gateway on a [Kubernetes](http://kubernetes.io) clu
 To install/upgrade the chart with the release name `cluster-gateway`:
 
 ```bash
-$ helm upgrade -i cluster-gateway appscode/cluster-gateway -n open-cluster-management --create-namespace --version=v2026.2.16
+$ helm upgrade -i cluster-gateway appscode/cluster-gateway -n open-cluster-management --create-namespace --version=v2026.6.26
 ```
 
 The command deploys a cluster-gateway on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -59,12 +59,12 @@ The following table lists the configurable parameters of the `cluster-gateway` c
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i cluster-gateway appscode/cluster-gateway -n open-cluster-management --create-namespace --version=v2026.2.16 --set image=ghcr.io/kluster-manager/cluster-gateway
+$ helm upgrade -i cluster-gateway appscode/cluster-gateway -n open-cluster-management --create-namespace --version=v2026.6.26 --set image=ghcr.io/kluster-manager/cluster-gateway
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i cluster-gateway appscode/cluster-gateway -n open-cluster-management --create-namespace --version=v2026.2.16 --values values.yaml
+$ helm upgrade -i cluster-gateway appscode/cluster-gateway -n open-cluster-management --create-namespace --version=v2026.6.26 --values values.yaml
 ```

--- a/charts/cluster-proxy-manager/Chart.yaml
+++ b/charts/cluster-proxy-manager/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cluster-proxy-manager
 description: A Helm chart for Cluster-Proxy OCM Addon
 type: application
-version: v2026.2.16
-appVersion: v0.10.0
+version: v2026.6.26
+appVersion: v0.10.1

--- a/charts/cluster-proxy-manager/README.md
+++ b/charts/cluster-proxy-manager/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable
 $ helm repo update
-$ helm search repo appscode/cluster-proxy-manager --version=v2026.2.16
-$ helm upgrade -i cluster-proxy-manager appscode/cluster-proxy-manager -n open-cluster-management-addon --create-namespace --version=v2026.2.16
+$ helm search repo appscode/cluster-proxy-manager --version=v2026.6.26
+$ helm upgrade -i cluster-proxy-manager appscode/cluster-proxy-manager -n open-cluster-management-addon --create-namespace --version=v2026.6.26
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a cluster-proxy-manager on a [Kubernetes](http://kubernetes.i
 To install/upgrade the chart with the release name `cluster-proxy-manager`:
 
 ```bash
-$ helm upgrade -i cluster-proxy-manager appscode/cluster-proxy-manager -n open-cluster-management-addon --create-namespace --version=v2026.2.16
+$ helm upgrade -i cluster-proxy-manager appscode/cluster-proxy-manager -n open-cluster-management-addon --create-namespace --version=v2026.6.26
 ```
 
 The command deploys a cluster-proxy-manager on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -69,12 +69,12 @@ The following table lists the configurable parameters of the `cluster-proxy-mana
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i cluster-proxy-manager appscode/cluster-proxy-manager -n open-cluster-management-addon --create-namespace --version=v2026.2.16 --set registry=ghcr.io/kluster-manager
+$ helm upgrade -i cluster-proxy-manager appscode/cluster-proxy-manager -n open-cluster-management-addon --create-namespace --version=v2026.6.26 --set registry=ghcr.io/kluster-manager
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i cluster-proxy-manager appscode/cluster-proxy-manager -n open-cluster-management-addon --create-namespace --version=v2026.2.16 --values values.yaml
+$ helm upgrade -i cluster-proxy-manager appscode/cluster-proxy-manager -n open-cluster-management-addon --create-namespace --version=v2026.6.26 --values values.yaml
 ```


### PR DESCRIPTION
Bump chart versions to `v2026.6.26`:

- `cluster-gateway` / `cluster-gateway-manager`: appVersion `v1.12.0` → `v1.12.1`
- `cluster-proxy-manager`: appVersion `v0.10.0` → `v0.10.1`

Updates `Chart.yaml` versions and regenerated `README.md` install snippets.