### PR TITLE
Modernize golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,27 +2,22 @@ version: "2"
 linters:
   default: standard
   enable:
+    - bodyclose
+    - prealloc
     - unparam
+  exclusions:
+    paths:
+      - generated.*\.go
+      - client
+      - vendor
 
 formatters:
   enable:
-    - gofmt
+    - gofumpt
     - goimports
-  settings:
-    gofmt:
-      rewrite-rules:
-        - pattern: 'interface{}'
-          replacement: 'any'
 
 issues:
   max-same-issues: 100
-
-  exclude-files:
-    - generated.*\\.go
-
-  exclude-dirs:
-    - client
-    - vendor
 
 run:
   timeout: 10m

--- a/apis/installer/v1alpha1/register.go
+++ b/apis/installer/v1alpha1/register.go
@@ -52,7 +52,8 @@ func Resource(resource string) schema.GroupResource {
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&ClusterAuth{},
 		&ClusterAuthList{},
 		&ClusterAuthManager{},
@@ -69,7 +70,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&SpokeClusterAddonsList{},
 	)
 
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&metav1.Status{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/apis/installer/v1alpha1/types_test.go
+++ b/apis/installer/v1alpha1/types_test.go
@@ -25,7 +25,8 @@ import (
 )
 
 func TestDefaultValues(t *testing.T) {
-	checker := sc.New(os.DirFS("../../.."),
+	checker := sc.New(
+		os.DirFS("../../.."),
 		sc.TestCase{Obj: v1alpha1.ClusterAuthSpec{}},
 		sc.TestCase{Obj: v1alpha1.ClusterAuthManagerSpec{}},
 		sc.TestCase{Obj: v1alpha1.ClusterManagerHubSpec{}},


### PR DESCRIPTION
- Enable bodyclose and prealloc linters
- Move exclude-files/exclude-dirs to linters.exclusions.paths (golangci-lint
  v2 location) and fix over-escaped regex generated.*\\.go -> generated.*\.go
- Switch formatter from gofmt to gofumpt and drop the interface{} -> any
  rewrite rule (gofumpt is a stricter superset)
- Apply resulting gofumpt formatting

Signed-off-by: Tamal Saha <tamal@appscode.com>
